### PR TITLE
Do not render `definition.previous` arrow at the beginning of the context

### DIFF
--- a/pytact/graph_visualize_browse.py
+++ b/pytact/graph_visualize_browse.py
@@ -148,8 +148,9 @@ class GraphVisualisationBrowser:
                                             target.depIndex, target.nodeIndex, dependencies, representative)
                         dot2.edge(id, id2,
                                  arrowtail="odot", dir="both", constraint="false", style="dashed")
-            dot.edge(id, self.node_id(0, value.label.definition.previous),
-                     arrowtail="dot", dir="both", constraint="true")
+            if value.label.definition.previous != len(nodes):
+                dot.edge(id, self.node_id(0, value.label.definition.previous),
+                         arrowtail="dot", dir="both", constraint="true")
             for fi in value.label.definition.externalPrevious:
                 fid = self.render_file_node(dot, dependencies, fi)
                 dot.edge(id, fid,


### PR DESCRIPTION
The value of `definition.previous` at the beginning of the context was changed
from the node itself to `len(graph.nodes)` between v9 and v11.