### PR TITLE
Simplify dependency visualization

### DIFF
--- a/pytact/visualisation_webserver.py
+++ b/pytact/visualisation_webserver.py
@@ -24,7 +24,10 @@ class VisualisationServer(BaseHTTPRequestHandler):
         dirname, basename = os.path.split(self.path)
         dirname = dirname.removeprefix('/')
         if basename == "file_deps.svg":
-            self.send_svg(self.gv.file_deps(dirname.split('/')))
+            expand_path = dirname.split('/')
+            if expand_path == ['']:
+                expand_path = []
+            self.send_svg(self.gv.file_deps(expand_path))
             return
         fname = dirname+".bin"
         print("fname:", fname)


### PR DESCRIPTION
This PR depends on #13.

I experimented with lots of different ways to visualize dependencies between
files. Problem is that almost any 'fancy' visualization gets overwhelmed by too
many nodes and edges. So here I'm going for something as simple as possible:

We can visualize all the direct subfolders and files within one directory, plus the
non-transitive edges between those subfolders. Edges that connect to anything
outside of the focused folder are unfortunately ignored (this gets too messy).
Edges between subfolders `a` and `b` are created if any files within `a` depend
on `b`. Note that with this setup, it is possible to create cycles between
folders. We collapse any strongly connected components within the dependency
graph into a single table-like node.

@mirefek can you take a look? What do you think? Any suggested improvements?